### PR TITLE
Add Johan Kjölhede (GiGurra) to signees

### DIFF
--- a/signees.csv
+++ b/signees.csv
@@ -19,3 +19,4 @@ Zhiming Wang,zmwangx
 Jan Kott,boostvolt
 Zhongrui Tao,ne275
 Maciej Mucha,mfly
+Johan Kjölhede,GiGurra


### PR DESCRIPTION
## Summary

- Add Johan Kjölhede (GiGurra) as a CLA signee